### PR TITLE
Fix the 1 second black screen bug

### DIFF
--- a/src/dxvk.conf
+++ b/src/dxvk.conf
@@ -1,5 +1,7 @@
 # DXVK configuration for World of Warcraft 1.12
 
+d3d9.enableDialogMode = True
+
 # Uncomment to set framerate limit
 # d3d9.maxFrameRate = 1000
 


### PR DESCRIPTION
I personally use Linux but I hear windows users have been suffering from the dxvk version of VF with the screen going black every time they alt tab in and out of the game. Someone today found this config setting resolves this issue, and I've had multiple people test this config change and confirm the problem is indeed solved.